### PR TITLE
fix bug in makefile path

### DIFF
--- a/makefiles/build.mk
+++ b/makefiles/build.mk
@@ -43,7 +43,7 @@ ALL_TASKS =
 DISK_TASKS =
 
 # try and load some target mappings for all platforms
--include ../makefiles/os.mk
+-include ./makefiles/os.mk
 
 
 CC := cl65


### PR DESCRIPTION
The path to `./makefiles/os.mk` was broken in previous changes.  Reverting it back to working path.