### PR TITLE
fixes to build & test c64

### DIFF
--- a/makefiles/build.mk
+++ b/makefiles/build.mk
@@ -217,7 +217,7 @@ endif
 
 test: $(PROGRAM_TGT)
 	$(PREEMUCMD)
-	$(EMUCMD) $(BUILD_DIR)\\$<
+	$(EMUCMD) $(BUILD_DIR)/$<
 	$(POSTEMUCMD)
 
 # Use "./" in front of all dirs being removed as a simple safety guard to

--- a/makefiles/custom-c64.mk
+++ b/makefiles/custom-c64.mk
@@ -12,6 +12,7 @@ endif
 
 SUFFIX = .prg
 DISK_TASKS += .create-d64
+VICE_HOME := $(dir $(shell which xvic))
 
 DISK_FILE = $(DIST_DIR)/$(PROGRAM).d64
 


### PR DESCRIPTION
Minor tweaks to make running the `c64` target test task work better